### PR TITLE
Avoid Using Windows Specific Paths

### DIFF
--- a/src/Dialogs/ProjectDialog/ProjectList.cs
+++ b/src/Dialogs/ProjectDialog/ProjectList.cs
@@ -92,8 +92,8 @@ namespace MapStudio.UI
 
         private void DisplayProject(string folder)
         {
-            string thumbFile = $"{folder}\\Thumbnail.png";
-            string projectFile = $"{folder}\\Project.json";
+            string thumbFile = Path.Combine(folder,"Thumbnail.png");
+            string projectFile = Path.Combine(folder,"Project.json");
             string projectName = new DirectoryInfo(folder).Name;
 
             if (!File.Exists(projectFile))

--- a/src/Dialogs/ProjectDialog/ProjectSaveDialog.cs
+++ b/src/Dialogs/ProjectDialog/ProjectSaveDialog.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -15,7 +16,7 @@ namespace MapStudio.UI
         public string GetProjectDirectory()
         {
             var settings = GlobalSettings.Current;
-            return $"{settings.Program.ProjectDirectory}\\{ProjectName}";
+            return Path.Combine(settings.Program.ProjectDirectory,ProjectName);
         }
 
         public ProjectSaveDialog(string name) {

--- a/src/DockedWindows/AssetWindow/AssetConfig.cs
+++ b/src/DockedWindows/AssetWindow/AssetConfig.cs
@@ -40,7 +40,7 @@ namespace MapStudio.UI
 
         public static AssetConfig Load()
         {
-            string path = $"{Runtime.ExecutableDir}\\Lib\\AssetConfig.json";
+            string path = Path.Combine(Runtime.ExecutableDir,"Lib","AssetConfig.json");
             if (!File.Exists(path))
                 new AssetConfig().Save();
 
@@ -50,7 +50,7 @@ namespace MapStudio.UI
         public void Save()
         {
             var json = JsonConvert.SerializeObject(this, Formatting.Indented);
-            File.WriteAllText($"{Runtime.ExecutableDir}\\Lib\\AssetConfig.json", json);
+            File.WriteAllText(Path.Combine(Runtime.ExecutableDir,"Lib","AssetConfig.json"), json);
         }
 
         public class AssetSettings

--- a/src/GlobalSettings.cs
+++ b/src/GlobalSettings.cs
@@ -74,9 +74,9 @@ namespace MapStudio.UI
         /// <returns></returns>
         public static GlobalSettings Load()
         {
-            if (!File.Exists($"{Runtime.ExecutableDir}\\ConfigGlobal.json")) { new GlobalSettings().Save(); }
+            if (!File.Exists(Path.Combine(Runtime.ExecutableDir,"ConfigGlobal.json"))) { new GlobalSettings().Save(); }
 
-            var config = JsonConvert.DeserializeObject<GlobalSettings>(File.ReadAllText($"{Runtime.ExecutableDir}\\ConfigGlobal.json"), new
+            var config = JsonConvert.DeserializeObject<GlobalSettings>(File.ReadAllText(Path.Combine(Runtime.ExecutableDir,"ConfigGlobal.json")), new
                 JsonSerializerSettings()
             {
                 //If settings get added, don't alter the defaults
@@ -128,7 +128,7 @@ namespace MapStudio.UI
         /// </summary>
         public void Save()
         {
-            File.WriteAllText($"{Runtime.ExecutableDir}\\ConfigGlobal.json", JsonConvert.SerializeObject(this, Formatting.Indented));
+            File.WriteAllText(Path.Combine(Runtime.ExecutableDir,"ConfigGlobal.json"), JsonConvert.SerializeObject(this, Formatting.Indented));
             ApplyConfiguration();
         }
 
@@ -223,7 +223,7 @@ namespace MapStudio.UI
             static string DefaultProjectPath()
             {
                 string local = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-                return $"{local}\\MapStudio";
+                return Path.Combine(local,"MapStudio");
             }
 
             public void ResetProjectDir() {

--- a/src/Imgui/ImGuiController/ImGuiController.cs
+++ b/src/Imgui/ImGuiController/ImGuiController.cs
@@ -70,7 +70,7 @@ namespace MapStudio.UI
                 (*nativeConfig).RasterizerMultiply = 1f;
                 (*nativeConfig).GlyphOffset = new System.Numerics.Vector2(0);
 
-                io.Fonts.AddFontFromFileTTF($"{Runtime.ExecutableDir}\\Lib\\Fonts\\Font.ttf", 16, nativeConfig);
+                io.Fonts.AddFontFromFileTTF(Path.Combine(Runtime.ExecutableDir,"Lib","Fonts","Font.ttf"), 16, nativeConfig);
             }
 
             //Merge icon fonts. Important that this goes after the main target font being used so it can be merged.
@@ -83,13 +83,13 @@ namespace MapStudio.UI
             char max = Convert.ToChar(0xe0fe);
             float fontSize = 16.0f;
 
-            AddFontFromFileTTF($"{Runtime.ExecutableDir}\\Lib\\Fonts\\OpenFontIcons.ttf", fontSize, config, new[] { min, max, (char)0 });
-            AddFontFromFileTTF($"{Runtime.ExecutableDir}\\Lib\\Fonts\\fa-solid-900.ttf", fontSize, config, new[] { (char)0xe005, (char)0xf8ff, (char)0 });
-            AddFontFromFileTTF($"{Runtime.ExecutableDir}\\Lib\\Fonts\\fa-regular-400.ttf", fontSize, config, new[] { (char)0xe005, (char)0xf8ff, (char)0 });
+            AddFontFromFileTTF(Path.Combine(Runtime.ExecutableDir,"Lib","Fonts","OpenFontIcons.ttf"), fontSize, config, new[] { min, max, (char)0 });
+            AddFontFromFileTTF(Path.Combine(Runtime.ExecutableDir,"Lib","Fonts","fa-solid-900.ttf"), fontSize, config, new[] { (char)0xe005, (char)0xf8ff, (char)0 });
+            AddFontFromFileTTF(Path.Combine(Runtime.ExecutableDir,"Lib","Fonts","fa-regular-400.ttf"), fontSize, config, new[] { (char)0xe005, (char)0xf8ff, (char)0 });
 
             //Font needs a slight shift.
             config.GlyphMinAdvanceX = 12;
-            AddFontFromFileTTF($"{Runtime.ExecutableDir}\\Lib\\Fonts\\NotoSansCJKjp-Medium.otf", fontSize, config, io.Fonts.GetGlyphRangesJapanese());
+            AddFontFromFileTTF(Path.Combine(Runtime.ExecutableDir,"Lib","Fonts","NotoSansCJKjp-Medium.otf"), fontSize, config, io.Fonts.GetGlyphRangesJapanese());
 
             //Store the default font for monospaced UI (ie hex viewer)
             DefaultFont = io.Fonts.AddFontDefault();
@@ -103,7 +103,7 @@ namespace MapStudio.UI
                 (*nativeConfig).RasterizerMultiply = 1f;
                 (*nativeConfig).GlyphOffset = new System.Numerics.Vector2(0);
 
-                DefaultFontBold = io.Fonts.AddFontFromFileTTF($"{Runtime.ExecutableDir}\\Lib\\Fonts\\FontBold.ttf", 16, nativeConfig);
+                DefaultFontBold = io.Fonts.AddFontFromFileTTF(Path.Combine(Runtime.ExecutableDir,"Lib","Fonts","FontBold.ttf"), 16, nativeConfig);
             }
 
             io.BackendFlags |= ImGuiBackendFlags.RendererHasVtxOffset;

--- a/src/Theme/ThemeHandler.cs
+++ b/src/Theme/ThemeHandler.cs
@@ -104,7 +104,7 @@ namespace MapStudio.UI
 
         public static void Load()
         {
-            string folder = $"{Toolbox.Core.Runtime.ExecutableDir}\\Lib\\Themes";
+            string folder = Path.Combine(Toolbox.Core.Runtime.ExecutableDir,"Lib","Themes");
             if (!Directory.Exists(folder))
                 Directory.CreateDirectory(folder);
 
@@ -116,12 +116,12 @@ namespace MapStudio.UI
 
         public static void Save()
         {
-            string folder = $"{Toolbox.Core.Runtime.ExecutableDir}\\Lib\\Themes";
+            string folder = Path.Combine(Toolbox.Core.Runtime.ExecutableDir,"Lib","Themes");
             if (!Directory.Exists(folder))
                 Directory.CreateDirectory(folder);
 
             foreach (var theme in Themes)
-                theme.Export($"{folder}\\{theme.Name}.json");
+                theme.Export(Path.Combine(folder,$"{theme.Name}.json"));
         }
 
         public void Export(string fileName)

--- a/src/UIFramework/Localization/TranslationSource.cs
+++ b/src/UIFramework/Localization/TranslationSource.cs
@@ -66,7 +66,7 @@ namespace MapStudio.UI
         public static List<string> GetLanguages()
         {
             List<string> languages = new List<string>();
-            foreach (var file in Directory.GetDirectories("Lib\\Languages")) {
+            foreach (var file in Directory.GetDirectories(Path.Combine("Lib","Languages"))) {
                 languages.Add(new DirectoryInfo(file).Name);
             }
             return languages;
@@ -85,8 +85,7 @@ namespace MapStudio.UI
         {
             if (LanguageKey == "English")
                 return;
-
-            foreach (var src in Directory.GetFiles($"{Runtime.ExecutableDir}\\Lib\\Languages/English"))
+            foreach (var src in Directory.GetFiles(Path.Combine(Runtime.ExecutableDir,"Lib","Languages","English")))
             {
                 string dest = src.Replace("Lib/Languages/English", $"Lib/Languages/{LanguageKey}");
                 DumpUntranslated(src, dest);
@@ -123,7 +122,7 @@ namespace MapStudio.UI
         static Dictionary<string, string> Load(string folder)
         {
             Dictionary<string, string> translated = new Dictionary<string, string>(); ;
-            foreach (var file in Directory.GetFiles($"{Runtime.ExecutableDir}\\Lib\\Languages/{folder}"))
+            foreach (var file in Directory.GetFiles(Path.Combine(Runtime.ExecutableDir,"Lib","Languages",folder)))
                 Load(file, translated);
             return translated;
         }

--- a/src/Updater/UpdaterHelper.cs
+++ b/src/Updater/UpdaterHelper.cs
@@ -90,8 +90,8 @@ namespace MapStudio.UI
             if (!release.Assets[assetIndex].UpdatedAt.ToString().Equals(currentDate) || force)
             {
                 //Remove existing install directories if they exist
-                if (Directory.Exists($"{folder}\\{"latest"}" + "/"))
-                    Directory.Delete($"{folder}\\{"latest"}" + "/", true);
+                if (Directory.Exists(Path.Combine(folder,"latest")))
+                    Directory.Delete(Path.Combine(folder,"latest"), true);
 
                 DownloadRelease(folder, release, assetIndex).Wait();
             }
@@ -124,7 +124,7 @@ namespace MapStudio.UI
                     Thread.Sleep(20);
                 };
                 Uri uri = new Uri(address);
-                await webClient.DownloadFileTaskAsync(uri, $"{folder}\\{name}.zip").ConfigureAwait(false);
+                await webClient.DownloadFileTaskAsync(uri, Path.Combine(folder,$"{name}.zip")).ConfigureAwait(false);
 
              //   progressBar.Dispose();
 
@@ -134,7 +134,7 @@ namespace MapStudio.UI
 
                 Console.WriteLine($"Extracting update!");
                 //Extract the zip for intalling
-                ExtractZip($"{folder}\\{name}");
+                ExtractZip(Path.Combine(folder,name));
 
                 ProcessLoading.Instance.Update(90, 100, $"Updating version to {_version_txt}!", "Updater");
 
@@ -167,9 +167,9 @@ namespace MapStudio.UI
         /// </summary>
         public static void Install(string folderDir)
         {
-            string path = $"{folderDir}\\latest\\net5.0";
+            string path = Path.Combine(folderDir,"latest","net5.0");
             if (!Directory.Exists(path))
-                path = $"{folderDir}\\latest";
+                path = Path.Combine(folderDir,"latest");
 
             if (!Directory.Exists(path)) {
                 Console.WriteLine($"No downloaded directory found!");
@@ -203,7 +203,7 @@ namespace MapStudio.UI
 
                 File.Move(file, Path.Combine(folderDir, Path.GetFileName(file)));
             }
-            Directory.Delete($"{folderDir}\\latest", true);
+            Directory.Delete(Path.Combine(folderDir,"latest"), true);
         }
 
         static async Task GetReleases(GitHubClient client)
@@ -217,10 +217,10 @@ namespace MapStudio.UI
         //
         static string GetRepoCompileDate(string folder)
         {
-            if (!File.Exists($"{folder}\\{_version_txt}"))
+            if (!File.Exists(Path.Combine(folder,_version_txt)))
                 return "";
 
-            string[] versionInfo = File.ReadLines($"{folder}\\{_version_txt}").ToArray();
+            string[] versionInfo = File.ReadLines(Path.Combine(folder,_version_txt)).ToArray();
             if (versionInfo.Length >= 3)
                 return versionInfo[1];
 
@@ -230,7 +230,7 @@ namespace MapStudio.UI
         //Stores the current release information within a .txt file
         static void WriteRepoVersion(string folder, Release release)
         {
-            using (StreamWriter writer = new StreamWriter($"{folder}\\{_version_txt}"))
+            using (StreamWriter writer = new StreamWriter(Path.Combine(folder,_version_txt)))
             {
                 writer.WriteLine($"{release.TagName}");
                 writer.WriteLine($"{release.Assets[0].UpdatedAt.ToString()}");

--- a/src/Workspace/ProjectResources.cs
+++ b/src/Workspace/ProjectResources.cs
@@ -41,7 +41,7 @@ namespace MapStudio.UI
             string dir = ProjectFile.WorkingDirectory;
 
             foreach (var asset in ProjectFile.FileAssets)
-                workspace.LoadFileFormat($"{ProjectFolder}\\{asset}", true);
+                workspace.LoadFileFormat(Path.Combine(ProjectFolder,asset), true);
 
             ProjectFile.LoadSettings(context, workspace);
             ProjectFile.WorkingDirectory = dir;
@@ -60,10 +60,10 @@ namespace MapStudio.UI
                 string path = asset.FileInfo.FileName;
 
                 ProjectFile.FileAssets.Add(path);
-                if (!File.Exists($"{ProjectFolder}\\{path}") && File.Exists(asset.FileInfo.FilePath))
-                    File.Copy(asset.FileInfo.FilePath, $"{ProjectFolder}\\{path}");
+                if (!File.Exists(Path.Combine(ProjectFolder,path)) && File.Exists(asset.FileInfo.FilePath))
+                    File.Copy(asset.FileInfo.FilePath, Path.Combine(ProjectFolder,path));
                 else
-                    asset.Save(File.OpenWrite($"{ProjectFolder}\\{path}"));
+                    asset.Save(File.OpenWrite(Path.Combine(ProjectFolder,path)));
             }
             //Save json file
             ProjectFile.Save(filePath);

--- a/src/Workspace/Workspace.cs
+++ b/src/Workspace/Workspace.cs
@@ -591,7 +591,7 @@ namespace MapStudio.UI
             if (!string.IsNullOrEmpty(Resources.ProjectFolder))
             {
                 string dir = Resources.ProjectFile.WorkingDirectory;
-                filePath = $"{dir}\\{Path.GetFileName(filePath)}";
+                filePath = Path.Combine(dir,Path.GetFileName(filePath));
                 SaveFileData(file, filePath);
                 return;
             }
@@ -671,13 +671,13 @@ namespace MapStudio.UI
             SaveEditorData(true);
             //Save as project
             OnProjectSave?.Invoke(this, EventArgs.Empty);
-            Resources.SaveProject($"{folderPath}\\Project.json", ViewportWindow.Pipeline._context, this);
+            Resources.SaveProject(Path.Combine(folderPath,"Project.json"), ViewportWindow.Pipeline._context, this);
             //Save the thumbnail in the current view
             var thumb = ViewportWindow.SaveAsScreenshot(720, 512);
-            thumb.Save($"{folderPath}\\Thumbnail.png");
+            thumb.Save(Path.Combine(folderPath,"Thumbnail.png"));
 
             //Update icon cache for thumbnails used
-            IconManager.LoadTextureFile($"{folderPath}\\Thumbnail.png", 64, 64, true);
+            IconManager.LoadTextureFile(Path.Combine(folderPath,"Thumbnail.png"), 64, 64, true);
 
             PrintErrors();
         }


### PR DESCRIPTION
Hello,

This fixes an issue I encountered when trying to run Track-Studio on my MacOS & Linux machines. Due to the usage of Windows specific paths, the program crashes when it tries to find a file on MacOS/Linux.

Since there are other issue that occur when running Track-Studio on Linux, I wasn't able to really test the code, but I have been able to compile the code just fine.