### PR TITLE
Auto detect more texture types + fix file dialog on Linux

### DIFF
--- a/src/Dialogs/FileDialog/TinyFileDialog.cs
+++ b/src/Dialogs/FileDialog/TinyFileDialog.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Runtime.InteropServices;
 using Toolbox.Core;
 
@@ -34,12 +33,14 @@ namespace MapStudio.UI
         public static string OpenFileDialog(List<FileFilter> filters, string fileName, bool multiSelect)
         {
             string[] filterList = toFilterArray(filters);
+            fileName ??= Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
             return stringFromAnsi(tinyfd_openFileDialog("Open File", fileName, filterList.Length, filterList, "", multiSelect ? 1 : 0)); ;
         }
 
         public static string SaveFileDialog(List<FileFilter> filters, string fileName)
         {
             string[] filterList = toFilterArray(filters);
+            fileName ??= Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
             return stringFromAnsi(tinyfd_saveFileDialog("Save File", fileName, filterList.Length, filterList, "")); ;
         }
 

--- a/src/Dialogs/FileDialog/TinyFileDialog.cs
+++ b/src/Dialogs/FileDialog/TinyFileDialog.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Runtime.InteropServices;
 using Toolbox.Core;
 
@@ -40,7 +41,8 @@ namespace MapStudio.UI
         public static string SaveFileDialog(List<FileFilter> filters, string fileName)
         {
             string[] filterList = toFilterArray(filters);
-            fileName ??= Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            if (Path.GetDirectoryName(fileName) is not { Length: > 0 })
+                fileName = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), fileName);
             return stringFromAnsi(tinyfd_saveFileDialog("Save File", fileName, filterList.Length, filterList, "")); ;
         }
 

--- a/src/Dialogs/TextureDialog/ImportedTexture.cs
+++ b/src/Dialogs/TextureDialog/ImportedTexture.cs
@@ -337,9 +337,23 @@ namespace MapStudio.UI
                 }
             }
 
-            //Red only
-            if (isGrayscale && Name != null && Name.ToLower().EndsWith("spm"))
-                return TexFormat.BC4_UNORM;
+            if (Name != null)
+            {
+                var name = Name.ToLower();
+                
+                //Specular map suffix
+                if (name.EndsWith("spm"))
+                    //Greyscale = BC4 (red only), else BC3 (color)
+                    return isGrayscale ? TexFormat.BC4_UNORM : TexFormat.BC3_UNORM;
+
+                //Normal map suffix
+                if (name.EndsWith("nrm"))
+                    return TexFormat.BC1_UNORM;
+                
+                if (isAlphaTranslucent && name.EndsWith("emm"))
+                    return TexFormat.BC4_UNORM;
+            }
+
             //Has transparency
             if (isAlphaTranslucent)
                 return TexFormat.BC3_SRGB;

--- a/src/UIFramework/Util/FileUtility.cs
+++ b/src/UIFramework/Util/FileUtility.cs
@@ -20,7 +20,7 @@ namespace MapStudio.UI
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 Process.Start("explorer.exe", folderPath);
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                Process.Start("mimeopen", folderPath);
+                Process.Start("xdg-open", folderPath);
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 Process.Start("open", $"-R \"{folderPath}\"");
         }
@@ -40,7 +40,7 @@ namespace MapStudio.UI
                 Process.Start("explorer.exe", argument);
             }
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                Process.Start("mimeopen", filePath);
+                Process.Start("xdg-open", filePath);
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 Process.Start("open", $"-R \"{filePath}\"");
         }


### PR DESCRIPTION


- Add normal map (ending in nrm), colored specular map (if the texture ends in spm but isn't greyscale) and translucent emission map (ending in emm and has transparency) detection to TryDetectFormat

- Replace usage of mimeopen with xdg-open (as xdg-open is installed on most linux distros)
- Specify a file in TinyFileDialog if fileName is null (now opens Documents) as the default path would get incorrectly split (e.g. "home/infina/Documents/Track" as the path + filename and "Studio/net8.0" as the mimetype)
- Add Documents path to fileName if fileName doesn't contain the file's directory (would previously still cause the path splitting issue as the directory was only being added if fileName was null)